### PR TITLE
Add arm64 python package

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -432,6 +432,15 @@
   },
   {
     "id": "python",
+    "version": "3.11.1",
+    "bitness": 64,
+    "arch": "aarch64",
+    "windows_url": "https://www.python.org/ftp/python/3.11.1/python-3.11.1-embed-arm64.zip",
+    "activated_cfg": "PYTHON='%installation_dir%/python.exe'",
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/python.exe"
+  },
+  {
+    "id": "python",
     "version": "3.9.2",
     "bitness": 64,
     "arch": "x86_64",
@@ -739,6 +748,14 @@
     "bitness": 64,
     "uses": ["node-14.18.2-64bit", "python-3.9.2-nuget-64bit", "java-8.152-64bit", "releases-upstream-%releases-tag%-64bit"],
     "os": "win",
+    "custom_install_script": "emscripten_npm_install"
+  },
+  {
+    "version": "releases-upstream-%releases-tag%",
+    "bitness": 64,
+    "uses": ["python-3.11.1-64bit"],
+    "os": "win",
+    "arch": "aarch64",
     "custom_install_script": "emscripten_npm_install"
   },
   {


### PR DESCRIPTION
This PR add installation of Arm64 Python from the Python official binary distribution to emsdk.py.